### PR TITLE
feat: Customise prefix for commit messages created by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,16 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "fix: "
+      prefix: "fix"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "monthly"
+    commit-message:
+      # Prefix all commit messages with "fix: "
+      prefix: "fix"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
     commit-message:
       # Prefix all commit messages with "fix: "
       prefix: "fix"
+      include: "scope"
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,8 @@ updates:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
     commit-message:
-      # Prefix all commit messages with "fix: "
-      prefix: "fix"
+      # Prefix all commit messages with "CHANGEME: "
+      prefix: "CHANGEME"
       include: "scope"
 
   - package-ecosystem: "pip"
@@ -21,7 +21,3 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "monthly"
-    commit-message:
-      # Prefix all commit messages with "fix: "
-      prefix: "fix"
-      include: "scope"


### PR DESCRIPTION
## Description

PR customises commit messages created by `dependabot` while updating `github-actions`.

## Motivation and Context

In https://github.com/PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/pull/73 title was manually changed in order to trigger release, in https://github.com/PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/pull/78 there was no change of title and no release was triggered. For future to avoid manual step we can:
- do release with commit containing prefix `chore` - it can be achieved by changing release rules according to https://github.com/semantic-release/commit-analyzer?tab=readme-ov-file#releaserules
- change prefix added by `dependabot` - it can be done by adding `prefix` to `dependabot.yml` file according to https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message

In PR second solution was chosen, because it allows in future to add commits with `chore` prefix, which are not changing anything in code and should not trigger release.

By purpose invalid prefix `CHANGEME` is configured in order to put correct one - if there are breaking changes, then new minor version should be created, but if there are no breaking changes, then only patch version is required.

## How Has This Been Tested?

Code will be tested next time `dependabot` creates PR.

If that change will work correctly, later it can be applied for other repositories:
* [terraform-aws-vmseries-modules](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules)
* [terraform-azurerm-vmseries-modules](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules)
* [terraform-google-vmseries-modules](https://github.com/PaloAltoNetworks/terraform-google-vmseries-modules)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
