### PR TITLE
fix(ci): Pin GitHub Actions

### DIFF
--- a/.github/workflows/_comment_pr.yml
+++ b/.github/workflows/_comment_pr.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: find if we have a comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
         id: find
         with:
           issue-number: ${{ inputs.pr_number }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: update comment
         if: steps.find.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           comment-id: ${{ steps.find.outputs.comment-id }}
           issue-number: ${{ inputs.pr_number }}

--- a/.github/workflows/_pre-commit-update.yml
+++ b/.github/workflows/_pre-commit-update.yml
@@ -30,10 +30,10 @@ jobs:
       pr_operation: ${{ steps.pr.outputs.pull-request-operation }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
 
       - name: set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: '3.11'
           cache: pip
@@ -48,7 +48,7 @@ jobs:
 
       - name: create pull request
         id: pr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e
         with:
           add-paths: .pre-commit-config.yaml
           branch: ${{ inputs.update_branch }}

--- a/.github/workflows/_pre_commit.yml
+++ b/.github/workflows/_pre_commit.yml
@@ -52,13 +52,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
         with:
           ref: ${{ inputs.branch }}
           repository: ${{ inputs.repository }}
 
       - name: set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: '3.11'
           cache: pip
@@ -85,7 +85,7 @@ jobs:
         run: python3 -m pip install -r requirements.txt
 
       - name: cache pre-commit dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/_tf_test.yml
+++ b/.github/workflows/_tf_test.yml
@@ -154,7 +154,7 @@ jobs:
     steps:
 
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
 
       - name: cleanup Azure Subscription
         if: inputs.cloud == 'azure'

--- a/.github/workflows/actions_release_ci.yml
+++ b/.github/workflows/actions_release_ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
 
       - name: sem release
         id: rc

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -21,6 +21,6 @@ jobs:
     name: Validate PR title matches conventional commits
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -52,7 +52,7 @@ jobs:
       changed_files: ${{ steps.format.outputs.files_diff }}
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
         with:
           fetch-depth: 0
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: get diff with base branch, examples, varfiles
         id: diff_tfvars
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@a29e8b565651ce417abb5db7164b4a2ad8b6155c
         with:
           separator: "@"
           files: examples/**/*.tfvars
@@ -208,7 +208,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check statuses of other jobs
-        uses: technote-space/workflow-conclusion-action@v3
+        uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5
 
       - name: branch protection check validation point
         run: |

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -145,7 +145,7 @@ jobs:
       issues: read
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
 
       - name: Create release and publish
         uses: cycjimmy/semantic-release-action@v4

--- a/.github/workflows/test_command.yml
+++ b/.github/workflows/test_command.yml
@@ -53,7 +53,7 @@ jobs:
       paths: ${{ steps.paths_reformat.outputs.paths }}
     steps:
       - name: add comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr-id }}


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions