### PR TITLE
fix: Upgrade terraform-docs and tflint

### DIFF
--- a/.github/workflows/_pre_commit.yml
+++ b/.github/workflows/_pre_commit.yml
@@ -71,7 +71,7 @@ jobs:
         if: ${{ matrix.pre_commit_hook == 'terraform_docs' }}
         working-directory: /tmp
         run: |
-          curl -sL https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-linux-amd64.tar.gz > terraform-docs.tar.gz 
+          curl -sL https://github.com/terraform-docs/terraform-docs/releases/download/v0.19.0/terraform-docs-v0.19.0-linux-amd64.tar.gz > terraform-docs.tar.gz
           tar zxf terraform-docs.tar.gz
           mv terraform-docs /usr/local/bin/
           terraform-docs --version
@@ -80,7 +80,7 @@ jobs:
         if: ${{ matrix.pre_commit_hook == 'terraform_tflint' }}
         working-directory: /tmp
         run: |
-          curl -sL https://github.com/terraform-linters/tflint/releases/download/v0.48.0/tflint_linux_amd64.zip > tflint.zip
+          curl -sL https://github.com/terraform-linters/tflint/releases/download/v0.55.0/tflint_linux_amd64.zip > tflint.zip
           unzip tflint.zip
           mv tflint /usr/local/bin/
           tflint --version


### PR DESCRIPTION
## Description

PR upgrades `terraform-docs` to `v0.19.0` and `tflint` to `v0.55.0`.

## Motivation and Context

While preparing https://github.com/PaloAltoNetworks/terraform-aws-swfw-modules/pull/99 with newest version of `terraform-docs` on my local machine, there were multiple changes in all `README.md` files, because in version https://github.com/terraform-docs/terraform-docs/releases/tag/v0.19.0 it was resolved fix: `78e94da fix: Replace <br> with <br /> for markdown syntax`. 

## How Has This Been Tested?

Newest versions of tools were tested only locally. 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
