### PR TITLE
ci: Pin external GitHub Actions

### DIFF
--- a/.github/workflows/_comment_pr.yml
+++ b/.github/workflows/_comment_pr.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: find if we have a comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: find
         with:
           issue-number: ${{ inputs.pr_number }}
@@ -41,7 +41,7 @@ jobs:
 
       - name: create comment
         if: steps.find.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4
         with:
           issue-number: ${{ inputs.pr_number }}
           body: ${{ steps.comment.outputs.body }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: update comment
         if: steps.find.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4
         with:
           comment-id: ${{ steps.find.outputs.comment-id }}
           issue-number: ${{ inputs.pr_number }}

--- a/.github/workflows/_pre-commit-update.yml
+++ b/.github/workflows/_pre-commit-update.yml
@@ -30,10 +30,10 @@ jobs:
       pr_operation: ${{ steps.pr.outputs.pull-request-operation }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
         with:
           python-version: '3.11'
           cache: pip
@@ -48,7 +48,7 @@ jobs:
 
       - name: create pull request
         id: pr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           add-paths: .pre-commit-config.yaml
           branch: ${{ inputs.update_branch }}

--- a/.github/workflows/_pre_commit.yml
+++ b/.github/workflows/_pre_commit.yml
@@ -51,19 +51,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.branch }}
           repository: ${{ inputs.repository }}
 
       - name: set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
         with:
           python-version: "3.11"
           cache: pip
 
       - name: setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_wrapper: false
 
@@ -89,7 +89,7 @@ jobs:
         run: python3 -m pip install -r requirements.txt
 
       - name: cache pre-commit dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/_tf_test.yml
+++ b/.github/workflows/_tf_test.yml
@@ -95,7 +95,7 @@ jobs:
         path: ${{ fromJson(needs.prerequisites.outputs.paths) }}
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ inputs.branch }}
           repository: ${{ inputs.repository }}
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: cleanup Azure Subscription
         if: inputs.cloud == 'azure'

--- a/.github/workflows/actions_release_ci.yml
+++ b/.github/workflows/actions_release_ci.yml
@@ -25,16 +25,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: sem release
         id: rc
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4
         with:
           semantic_version: 19.0
           extra_plugins: |
-            conventional-changelog-conventionalcommits@^5.0.0
-            @semantic-release/git@^10.0.1
+            conventional-changelog-conventionalcommits@ba6df7cf62de5f448368bed4398f6ddf633d2cbd
+            @semantic-release/git@3e934d45f97fd07a63617c0fc098c9ed3e67d97a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -21,6 +21,6 @@ jobs:
     name: Validate PR title matches conventional commits
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -50,7 +50,7 @@ jobs:
       changed_files: ${{ steps.format.outputs.files_diff }}
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check statuses of other jobs
-        uses: technote-space/workflow-conclusion-action@v3
+        uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3
 
       - name: branch protection check validation point
         run: |

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -46,17 +46,17 @@ jobs:
       rc: ${{ steps.rc.outputs.new_release_published }}
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: dry-run sem versioning
         id: rc
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4
         with:
           dry_run: true
           semantic_version: 19.0
           extra_plugins: |
-            conventional-changelog-conventionalcommits@^5.0.0
-            @semantic-release/git@^10.0.1
+            conventional-changelog-conventionalcommits@ba6df7cf62de5f448368bed4398f6ddf633d2cbd
+            @semantic-release/git@3e934d45f97fd07a63617c0fc098c9ed3e67d97a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -86,7 +86,7 @@ jobs:
       examples: ${{ steps.paths.outputs.examples }}
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: set outputs
         id: paths
         shell: bash
@@ -145,14 +145,14 @@ jobs:
       issues: read
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Create release and publish
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4
         with:
           semantic_version: 19.0
           extra_plugins: |
-            conventional-changelog-conventionalcommits@^5.0.0
-            @semantic-release/git@^10.0.1
+            conventional-changelog-conventionalcommits@ba6df7cf62de5f448368bed4398f6ddf633d2cbd
+            @semantic-release/git@3e934d45f97fd07a63617c0fc098c9ed3e67d97a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_command.yml
+++ b/.github/workflows/test_command.yml
@@ -53,7 +53,7 @@ jobs:
       paths: ${{ steps.paths_reformat.outputs.paths }}
     steps:
       - name: add comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr-id }}
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: add comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr-id }}


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions