### PR TITLE
fix(ci): Updated extra_plugins params for semntic release to work with sha pins

### DIFF
--- a/.github/workflows/actions_release_ci.yml
+++ b/.github/workflows/actions_release_ci.yml
@@ -8,10 +8,9 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 * * 3' # this means every Wednesday @1am UTC
+    - cron: "0 1 * * 3" # this means every Wednesday @1am UTC
 
 jobs:
-
   pre_commit:
     name: Pre-Commit
     uses: ./.github/workflows/_pre_commit.yml
@@ -20,7 +19,7 @@ jobs:
 
   release:
     name: Semantic release
-    needs: 
+    needs:
       - pre_commit
     runs-on: ubuntu-latest
     steps:
@@ -33,11 +32,11 @@ jobs:
         with:
           semantic_version: 19.0
           extra_plugins: |
-            conventional-changelog-conventionalcommits@ba6df7cf62de5f448368bed4398f6ddf633d2cbd
-            @semantic-release/git@3e934d45f97fd07a63617c0fc098c9ed3e67d97a
+            https://gitpkg.vercel.app/conventional-changelog/conventional-changelog/packages/conventional-changelog-conventionalcommits?ba6df7cf62de5f448368bed4398f6ddf633d2cbd
+            semantic-release/git#3e934d45f97fd07a63617c0fc098c9ed3e67d97a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: create major release tag
         if: steps.rc.outputs.new_release_published == 'true'
         env:

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -55,8 +55,8 @@ jobs:
           dry_run: true
           semantic_version: 19.0
           extra_plugins: |
-            conventional-changelog-conventionalcommits@ba6df7cf62de5f448368bed4398f6ddf633d2cbd
-            @semantic-release/git@3e934d45f97fd07a63617c0fc098c9ed3e67d97a
+            https://gitpkg.vercel.app/conventional-changelog/conventional-changelog/packages/conventional-changelog-conventionalcommits?ba6df7cf62de5f448368bed4398f6ddf633d2cbd
+            semantic-release/git#3e934d45f97fd07a63617c0fc098c9ed3e67d97a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -65,7 +65,6 @@ jobs:
           echo new_release_published - ${{ steps.rc.outputs.new_release_published }}
           echo new_release_version - ${{ steps.rc.outputs.new_release_version }}
           echo last_release_version - ${{ steps.rc.outputs.last_release_version }}
-
 
   pre_commit:
     name: Pre-Commit
@@ -111,7 +110,6 @@ jobs:
       max_parallel: ${{ inputs.validate_max_parallel }}
     secrets: inherit
 
-
   test:
     name: run ${{ inputs.terratest_action }} tests on examples
     needs:
@@ -132,7 +130,6 @@ jobs:
       apply_timeout: ${{ inputs.apply_timeout }}
     secrets: inherit
 
-
   release:
     name: release sem version
     needs:
@@ -152,7 +149,7 @@ jobs:
         with:
           semantic_version: 19.0
           extra_plugins: |
-            conventional-changelog-conventionalcommits@ba6df7cf62de5f448368bed4398f6ddf633d2cbd
-            @semantic-release/git@3e934d45f97fd07a63617c0fc098c9ed3e67d97a
+            https://gitpkg.vercel.app/conventional-changelog/conventional-changelog/packages/conventional-changelog-conventionalcommits?ba6df7cf62de5f448368bed4398f6ddf633d2cbd
+            semantic-release/git#3e934d45f97fd07a63617c0fc098c9ed3e67d97a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Updated semantic release action :

```yaml
      - name: sem release
        id: rc
        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4
        with:
          semantic_version: 19.0
          extra_plugins: |
            https://gitpkg.vercel.app/conventional-changelog/conventional-changelog/packages/conventional-changelog-conventionalcommits?ba6df7cf62de5f448368bed4398f6ddf633d2cbd
            semantic-release/git#3e934d45f97fd07a63617c0fc098c9ed3e67d97a
```

## Motivation and Context

Previous sha pinning syntax was not working.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
