### PR TITLE
ci: Bump TF Docs version

### DIFF
--- a/.github/workflows/_pre_commit.yml
+++ b/.github/workflows/_pre_commit.yml
@@ -83,7 +83,7 @@ jobs:
         if: ${{ matrix.pre_commit_hook == 'terraform_tflint' }}
         working-directory: /tmp
         run: |
-          curl -sL https://github.com/terraform-linters/tflint/releases/download/v0.48.0/tflint_linux_amd64.zip > tflint.zip
+          curl -sL https://github.com/terraform-linters/tflint/releases/download/v0.58.0/tflint_linux_amd64.zip > tflint.zip
           unzip tflint.zip
           mv tflint /usr/local/bin/
           tflint --version


### PR DESCRIPTION
PR upgrades terraform-docs to `v0.20.0`  and TFLint to `v0.58.0`