### PR TITLE
fix(workflows): Adjust _tf_test workflow to exclude AWS Cloud NGFW tests

### DIFF
--- a/.github/workflows/_tf_test.yml
+++ b/.github/workflows/_tf_test.yml
@@ -115,7 +115,7 @@ jobs:
           pr-id: ${{ inputs.pr-id }}
 
       - name: run tests on AWS
-        if: inputs.cloud == 'aws'
+        if: inputs.cloud == 'aws' && matrix.path != 'examples/cloudngfw_isolated_design' && matrix.path != 'examples/cloudngfw_combined_design'
         timeout-minutes: ${{ inputs.apply_timeout }}
         uses: ./.github/actions/terratest
         env:


### PR DESCRIPTION
## Description
This is a temporary change to exclude Cloud NGFW examples in AWS from testing. It is related to the provider bug that affects AWS code release and must be resolved. 

## How Has This Been Tested?
Locally tested on a cloned repository

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
