### PR TITLE
fix(actions_release): Upgrade semantic-release and pin plugin dependencies

### DIFF
--- a/.github/workflows/actions_release_ci.yml
+++ b/.github/workflows/actions_release_ci.yml
@@ -30,10 +30,10 @@ jobs:
         id: rc
         uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4
         with:
-          semantic_version: 19.0
+          semantic_version: 25.0
           extra_plugins: |
-            https://gitpkg.vercel.app/conventional-changelog/conventional-changelog/packages/conventional-changelog-conventionalcommits?ba6df7cf62de5f448368bed4398f6ddf633d2cbd
-            semantic-release/git#3e934d45f97fd07a63617c0fc098c9ed3e67d97a
+              conventional-changelog-conventionalcommits@9.1.0
+              semantic-release/git#3e934d45f97fd07a63617c0fc098c9ed3e67d97a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

This PR updates the Semantic Release and pin plugin dependencies version. 

## Motivation and Context

Download is failing for currently configured conventional-changelog-conventionalcommits plugin. To make the functionality of newly pinned plugin version working properly, upgrade of semantic-release was required as well.

## How Has This Been Tested?

Release tested in forked repository 

## Screenshots (if appropriate)
Fix release
<img width="1010" height="50" alt="Screenshot 2025-11-28 at 11 29 55" src="https://github.com/user-attachments/assets/ca851910-d434-4eb8-84f8-9d1aa27ea3a8" />

Feat (breaking and non-breking)
<img width="997" height="104" alt="Screenshot 2025-11-27 at 18 09 02" src="https://github.com/user-attachments/assets/03d9c767-9b8e-41d8-93a2-9f078295397b" />

Major release
<img width="958" height="44" alt="Screenshot 2025-11-28 at 11 29 28" src="https://github.com/user-attachments/assets/0cfa8d2a-ec8f-4233-b5cd-512c492ea9c8" />


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
